### PR TITLE
More error-checking and interact with IO objects

### DIFF
--- a/lib/sgf/collection_assembler.rb
+++ b/lib/sgf/collection_assembler.rb
@@ -13,6 +13,10 @@ class SGF::CollectionAssembler
     @branches = []
   end
 
+  def unclosed_branches_count
+    @branches.size
+  end
+
   def open_branch
     @branches.unshift @current_node
   end

--- a/lib/sgf/error_checkers.rb
+++ b/lib/sgf/error_checkers.rb
@@ -10,10 +10,25 @@ class SGF::StrictErrorChecker
       raise(SGF::MalformedDataError, msg)
     end
   end
+
+  def check_for_errors_after_parsing(assembler)
+    unclosed_count = assembler.unclosed_branches_count
+    return true if unclosed_count.zero?
+
+    msg = "SGF file ended with #{unclosed_count} unclosed branch"
+    msg += 'es' if unclosed_count > 1
+    msg += '. All opening parentheses "(" must have matching closing parentheses ")".'
+    raise SGF::MalformedDataError, msg
+  end
 end
 
 class SGF::LaxErrorChecker
   def check_for_errors_before_parsing(_string)
+    # just look the other way
+    true
+  end
+
+  def check_for_errors_after_parsing(_assembler)
     # just look the other way
     true
   end

--- a/lib/sgf/parser.rb
+++ b/lib/sgf/parser.rb
@@ -25,8 +25,8 @@ class SGF::Parser
   # The second argument is optional, in case you don't want this to raise errors.
   # You probably shouldn't use it, but who's gonna stop you?
   def parse(sgf, strict_parsing = true)
-    error_checker = strict_parsing ? SGF::StrictErrorChecker.new : SGF::LaxErrorChecker.new
-    @sgf_stream = SGF::Stream.new(sgf, error_checker)
+    @error_checker = strict_parsing ? SGF::StrictErrorChecker.new : SGF::LaxErrorChecker.new
+    @sgf_stream = SGF::Stream.new(sgf, @error_checker)
     @assembler = SGF::CollectionAssembler.new
     until @sgf_stream.eof?
       case @sgf_stream.next_character
@@ -38,6 +38,7 @@ class SGF::Parser
       else next
       end
     end
+    @error_checker.check_for_errors_after_parsing(@assembler)
     @assembler.collection
   end
 

--- a/lib/sgf/stream.rb
+++ b/lib/sgf/stream.rb
@@ -5,6 +5,7 @@ require 'stringio'
 class SGF::Stream
 
   def initialize(sgf_input, error_checker)
+    validate_input(sgf_input)
     @sgf_input = sgf_input
     @error_checker = error_checker
     @stream = nil
@@ -46,15 +47,17 @@ class SGF::Stream
 
   private
 
+  def validate_input(input)
+    return if input.is_a?(String)
+    return if input.respond_to?(:read)
+
+    raise ArgumentError, "SGF input must be a String or respond to :read, got #{input.class}"
+  end
+
   def read_sgf_input(input)
-    case
-    when input.respond_to?(:read) && !input.is_a?(String)
-      input.read
-    when input.is_a?(String) && File.exist?(input)
-      File.read(input)
-    else
-      input
-    end
+    return input.read if input.respond_to?(:read)
+    return File.read(input) if File.exist?(input)
+    input
   end
 
   def rewind

--- a/lib/sgf/stream.rb
+++ b/lib/sgf/stream.rb
@@ -3,12 +3,19 @@
 require 'stringio'
 
 class SGF::Stream
-  attr_reader :stream
 
-  def initialize(sgf, error_checker)
-    sgf_content = read_sgf_input(sgf)
-    error_checker.check_for_errors_before_parsing sgf_content
-    @stream = StringIO.new clean(sgf_content), 'r'
+  def initialize(sgf_input, error_checker)
+    @sgf_input = sgf_input
+    @error_checker = error_checker
+    @stream = nil
+  end
+
+  def stream
+    @stream ||= begin
+      sgf_content = read_sgf_input(@sgf_input)
+      @error_checker.check_for_errors_before_parsing sgf_content
+      StringIO.new clean(sgf_content), 'r'
+    end
   end
 
   def eof?

--- a/lib/sgf/stream.rb
+++ b/lib/sgf/stream.rb
@@ -47,9 +47,14 @@ class SGF::Stream
   private
 
   def read_sgf_input(input)
-    return input.read if input.respond_to?(:read) && !input.is_a?(String)
-    return File.read(input) if input.is_a?(String) && File.exist?(input)
-    input
+    case
+    when input.respond_to?(:read) && !input.is_a?(String)
+      input.read
+    when input.is_a?(String) && File.exist?(input)
+      File.read(input)
+    else
+      input
+    end
   end
 
   def rewind

--- a/lib/sgf/stream.rb
+++ b/lib/sgf/stream.rb
@@ -6,10 +6,9 @@ class SGF::Stream
   attr_reader :stream
 
   def initialize(sgf, error_checker)
-    sgf = sgf.read if sgf.respond_to?(:read) && !sgf.is_a?(String)
-    sgf = File.read(sgf) if sgf.is_a?(String) && File.exist?(sgf)
-    error_checker.check_for_errors_before_parsing sgf
-    @stream = StringIO.new clean(sgf), 'r'
+    sgf_content = read_sgf_input(sgf)
+    error_checker.check_for_errors_before_parsing sgf_content
+    @stream = StringIO.new clean(sgf_content), 'r'
   end
 
   def eof?
@@ -39,6 +38,12 @@ class SGF::Stream
   end
 
   private
+
+  def read_sgf_input(input)
+    return input.read if input.respond_to?(:read) && !input.is_a?(String)
+    return File.read(input) if input.is_a?(String) && File.exist?(input)
+    input
+  end
 
   def rewind
     stream.pos -= 1

--- a/lib/sgf/stream.rb
+++ b/lib/sgf/stream.rb
@@ -6,8 +6,8 @@ class SGF::Stream
   attr_reader :stream
 
   def initialize(sgf, error_checker)
-    sgf = sgf.read if sgf.instance_of?(File)
-    sgf = File.read(sgf) if File.exist?(sgf)
+    sgf = sgf.read if sgf.respond_to?(:read) && !sgf.is_a?(String)
+    sgf = File.read(sgf) if sgf.is_a?(String) && File.exist?(sgf)
     error_checker.check_for_errors_before_parsing sgf
     @stream = StringIO.new clean(sgf), 'r'
   end

--- a/lib/sgf/writer.rb
+++ b/lib/sgf/writer.rb
@@ -2,11 +2,14 @@
 
 class SGF::Writer
 
-  # Takes a node and a filename as arguments
-  def save(root_node, filename)
-    # TODO: - accept any I/O object?
+  # Takes a node and a filename/IO object as arguments
+  def save(root_node, output)
     stringify_tree_from root_node
-    File.open(filename, 'w') { |f| f << @sgf }
+    if output.respond_to?(:write)
+      output.write @sgf
+    else
+      File.open(output, 'w') { |f| f << @sgf }
+    end
   end
 
   def stringify_tree_from(root_node)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -158,4 +158,10 @@ RSpec.describe SGF::Parser do
     expect(game.root['PW']).to eq 'redrose'
     expect(game.root['PB']).to eq 'tartrate'
   end
+
+  it 'should raise ArgumentError if given invalid input type' do
+    expect { parser.parse(42) }.to raise_error(ArgumentError, /must be a String or respond to :read/)
+    expect { parser.parse(nil) }.to raise_error(ArgumentError, /must be a String or respond to :read/)
+    expect { parser.parse([]) }.to raise_error(ArgumentError, /must be a String or respond to :read/)
+  end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -132,4 +132,30 @@ RSpec.describe SGF::Parser do
     expect(game.root['PW']).to eq 'redrose'
     expect(game.root['PB']).to eq 'tartrate'
   end
+
+  it 'should parse a file if given a StringIO as input' do
+    sgf_content = File.read('spec/data/simple.sgf')
+    string_io = StringIO.new(sgf_content)
+    collection = parser.parse string_io
+    game = collection.gametrees.first
+    expect(game.root['PW']).to eq 'redrose'
+    expect(game.root['PB']).to eq 'tartrate'
+  end
+
+  it 'should parse a file if given any IO-like object with read method' do
+    sgf_content = File.read('spec/data/simple.sgf')
+    io_like = Class.new do
+      def initialize(content)
+        @content = content
+      end
+      def read
+        @content
+      end
+    end.new(sgf_content)
+
+    collection = parser.parse io_like
+    game = collection.gametrees.first
+    expect(game.root['PW']).to eq 'redrose'
+    expect(game.root['PB']).to eq 'tartrate'
+  end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe SGF::Parser do
       expect(collection).to eq expected
       expect(collection.errors).to include 'Multiple AB identities are present in a single node. A property should only exist once per node.'
     end
+
+    it 'should raise an error when parser reaches EOF with unclosed branches' do
+      invalid_sgf = '(;FF[4](;B[dd]'
+      expect { parser.parse invalid_sgf }.to raise_error SGF::MalformedDataError, /unclosed branches/i
+    end
+
+    it 'should raise an error when parser reaches EOF with multiple unclosed branches' do
+      invalid_sgf = '(;FF[4](;B[dd](;W[cc]'
+      expect { parser.parse invalid_sgf }.to raise_error(SGF::MalformedDataError, /3.*unclosed branches/i)
+    end
+
+    it 'should not raise error when branches are properly closed' do
+      valid_sgf = '(;FF[4](;B[dd]))'
+      expect { parser.parse valid_sgf }.not_to raise_error
+    end
   end
 
   it 'should parse a simple node' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 
 require_relative '../lib/sgf'
 require 'fileutils'
+require 'stringio'
 require 'pry' if ENV['PRY']
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -78,6 +78,36 @@ RSpec.describe SGF::Writer do
     expect(sgf).to eq expected
   end
 
+  it 'should save to a StringIO object' do
+    collection = parser.parse '(;FF[4]PW[Dosaku])'
+    output = StringIO.new
+    SGF::Writer.new.save(collection.root, output)
+    output.rewind
+    saved_content = output.read
+    expect(saved_content).to include 'FF[4]'
+    expect(saved_content).to include 'PW[Dosaku]'
+  end
+
+  it 'should save to any IO-like object with write method' do
+    collection = parser.parse '(;FF[4]PW[Dosaku])'
+    io_like = Class.new do
+      def initialize
+        @content = +'' # unary plus unfreezes the string
+      end
+      def write(data)
+        @content << data
+      end
+      def to_s
+        @content
+      end
+    end.new
+
+    SGF::Writer.new.save(collection.root, io_like)
+    saved_content = io_like.to_s
+    expect(saved_content).to include 'FF[4]'
+    expect(saved_content).to include 'PW[Dosaku]'
+  end
+
   private
 
   def parse_save_load_and_compare_to_saved(string)


### PR DESCRIPTION
This change implements strict validation to detect when an SGF file ends with unclosed branches (unmatched opening parentheses). The parser now raises a clear error message indicating how many branches remain unclosed.

Changes:
- Added unclosed_branches_count method to CollectionAssembler to expose the number of open branches
- Extended ErrorChecker pattern with check_for_errors_after_parsing method for both StrictErrorChecker and LaxErrorChecker implementations
- Updated Parser to use the ErrorChecker for post-parsing validation, maintaining consistency with the existing error-checking pattern
- Added comprehensive test coverage for single and multiple unclosed branches, as well as properly closed branches

The refactored design follows the established ErrorChecker pattern, keeping validation logic centralized and the Parser focused on parsing.